### PR TITLE
Refactor processObjectStream

### DIFF
--- a/lib/Tablinator/Table.hs
+++ b/lib/Tablinator/Table.hs
@@ -1,7 +1,8 @@
 module Tablinator.Table
 (
     Column(..),
-    processObjectStream
+    processObjectStream,
+    Alignment(..)
 ) where
 
 import Data.List (sort)

--- a/tests/Snippet.hs
+++ b/tests/Snippet.hs
@@ -40,7 +40,7 @@ example =
     [one,two]
 
 document :: Pandoc
-document = Pandoc nullMeta (processObjectStream example)
+document = Pandoc nullMeta [processObjectStream example]
 
 main :: IO ()
 main = putStrLn $ writeMarkdown def document

--- a/tests/Snippet.hs
+++ b/tests/Snippet.hs
@@ -2,23 +2,45 @@
 
 module Main where
 
-import Tablinator.Table
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
-import Text.Pandoc (Alignment(..))
+import Text.Pandoc
+
+import Tablinator.Table
 
 data LibraryBooks
     = Genre
     | Author
     | Title
     | Description
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Bounded, Enum, Show)
 
 instance Column LibraryBooks where
     heading x = T.pack $ show x
     alignment _ = AlignLeft
 
 
-main :: IO ()
-main = T.putStrLn $ heading Author
+example :: [Map LibraryBooks Text]
+example =
+  let
+    one = Map.fromList
+           [(Author, "Raymond E. Feist"),
+            (Genre,"Fantasy"),
+            (Description, "Pug and Thomas"),
+            (Title,"Magician")]
+    two = Map.fromList
+           [(Title,"Wuthering Heights"),
+            (Author, "Emily Brontë"),
+            (Genre,"Gothic"),
+            (Description, "It's all about Heathcliffe ")]
+  in
+    [one,two]
 
+document :: Pandoc
+document = Pandoc nullMeta (processObjectStream example)
+
+main :: IO ()
+main = putStrLn $ writeMarkdown def document


### PR DESCRIPTION
Split out the logic in `processObjectStream` into several smaller functions.

The actual aim was to get to the point where we could start exploiting the properties of the Column typeclass without needing to take columns from the first row of stream, but not there yet.
