### PR TITLE
Render columns as listed

### DIFF
--- a/lib/Tablinator/Table.hs
+++ b/lib/Tablinator/Table.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Tablinator.Table
 (
     Column(..),
     processObjectStream,
+    allColumns,
     Alignment(..)
 ) where
 
@@ -13,30 +16,45 @@ import qualified Data.Text as T
 import Text.Pandoc
 
 --
--- | A table column. You need to specify an Ord instance which will determine
--- the order of your columns, and implement the 'heading' method to give a
--- heading for each column in the output table
+-- | A table column. Columns are to be unique.  You need to specify an Ord
+-- instance which will determine the order of your columns, and implement the
+-- 'heading' method to give a heading for each column in the output table.
+-- 'alignment' will default to 'AlignLeft'; override at will.
 --
-class Ord a => Column a where
+class (Ord a, Enum a) => Column a where
     heading   :: a -> Text
+
     alignment :: a -> Alignment
+    alignment _ = AlignLeft
+
+
+--
+-- | Render all the columns of your type. This is a convenience function which
+-- gives you all the columns of your 'Enum', in 'Ord' order.
+--
+allColumns :: Column k => [k]
+allColumns = enumFrom $ toEnum 0
+
 
 headings :: Column k => Map k a -> [Text]
 headings m = fmap heading $ Map.keys m
 
 --
 -- | Given a stream (at present modelled as a list) of input data objects (each
--- represented as a Map), pivot into a compound pandoc Block, suitable
--- for subsequent emplacement in a Pandoc document.
+-- represented as a Map), pivot into a compound pandoc Block, suitable for
+-- subsequent emplacement in a Pandoc document. You pass in the list of columns
+-- from your Column type that you want rendered and then the records to be
+-- rendered; use 'allColumns' as a convenience if you want all of them in 'Ord'
+-- order.
 --
-processObjectStream :: Column k => [Map k Text] -> [Block]
-processObjectStream ms =
+processObjectStream :: Column k => [k] -> [Map k Text] -> Block
+processObjectStream order ms =
   let
-    heading = renderTableHeading ms
+    heading = renderTableHeading order ms
     body    = renderTableBody ms
     result  = heading body
   in
-    [result]
+    result
 
 type TableRow = [TableCell]
 
@@ -44,8 +62,8 @@ type TableRow = [TableCell]
 -- Return a function that expects a table body and results in a table.
 -- Partial application here; rows left to be supplied to Table constructor.
 --
-renderTableHeading :: Column k => [Map k Text] -> ([TableRow] -> Block)
-renderTableHeading ms =
+renderTableHeading :: Column k => [k] -> [Map k Text] -> ([TableRow] -> Block)
+renderTableHeading _ ms =
   let
     hdings  = fmap T.unpack (headings (head ms))
     inline  = [Str "This is the caption"]

--- a/tests/Snippet.hs
+++ b/tests/Snippet.hs
@@ -40,7 +40,8 @@ example =
     [one,two]
 
 document :: Pandoc
-document = Pandoc nullMeta [processObjectStream example]
+document = Pandoc nullMeta [processObjectStream allColumns example]
 
 main :: IO ()
 main = putStrLn $ writeMarkdown def document
+


### PR DESCRIPTION
Supply a list of columns, rather than just assuming all columns are to be rendered. 

We could probably drop the Ord requirement if we switched to **unordered-containers**'s Map but the use of `allColumns` seems likely to be colloquial and that _would_ need an Ord constraint... Oh, wrong: Data.HashMap.Strict needs Eq and Hashable keys. Bah. Nevermind.
