### PR TITLE
Update stackage snapshot to lts-5.13

### DIFF
--- a/lib/Tablinator/Table.hs
+++ b/lib/Tablinator/Table.hs
@@ -8,7 +8,6 @@ module Tablinator.Table
     Alignment(..)
 ) where
 
-import Data.List (sort)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
@@ -49,9 +48,9 @@ allColumns = enumFrom $ toEnum 0
 processObjectStream :: Column k => [k] -> [Map k Text] -> Block
 processObjectStream order ms =
   let
-    heading = renderTableHeading order
+    header  = renderTableHeading order
     body    = renderTableBody order ms
-    result  = heading body
+    result  = header body
   in
     result
 
@@ -85,10 +84,10 @@ renderTableHeading columns =
 --
 renderTableBody :: forall k. Column k => [k] -> [Map k Text] -> [TableRow]
 renderTableBody columns ms =
-    fmap (renderTableRow columns) ms
+    fmap renderTableRow ms
   where
-    renderTableRow :: [k] -> Map k Text -> TableRow
-    renderTableRow columns m = fmap (renderColumn m) columns
+    renderTableRow :: Map k Text -> TableRow
+    renderTableRow m = fmap (renderColumn m) columns
 
     renderColumn :: Map k Text -> k -> TableCell
     renderColumn m column =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-5.3
+resolver: lts-5.13
 packages:
 - '.'
 extra-deps: []

--- a/tests/CheckProgram.hs
+++ b/tests/CheckProgram.hs
@@ -13,7 +13,7 @@ data LibraryBooks
     | Author
     | Title
     | Description
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Enum, Show)
 
 instance Column LibraryBooks where
     heading x   = T.pack $ show x


### PR DESCRIPTION
Address warnings. Eliminate name shadowing and unnecessary imports.
